### PR TITLE
parse nested at-rules without a trailing semicolon

### DIFF
--- a/lib/scss-parser.es6
+++ b/lib/scss-parser.es6
@@ -1,3 +1,4 @@
+import AtRule  from 'postcss/lib/at-rule';
 import Comment from 'postcss/lib/comment';
 import Parser  from 'postcss/lib/parser';
 
@@ -29,6 +30,63 @@ export default class ScssParser extends Parser {
             }
         } else {
             super(token);
+        }
+    }
+
+    atrule(token) {
+        let node  = new AtRule();
+        node.name = token[1].slice(1);
+        if ( node.name === '' ) {
+            this.unnamedAtrule(node, token);
+        }
+        this.init(node, token[2], token[3]);
+
+        let last   = false;
+        let open   = false;
+        let params = [];
+
+        this.pos += 1;
+        while ( this.pos < this.tokens.length ) {
+            token = this.tokens[this.pos];
+
+            if ( token[0] === ';' ) {
+                node.source.end = { line: token[2], column: token[3] };
+                this.semicolon = true;
+                break;
+            } else if ( token[0] === '{' ) {
+                open = true;
+                break;
+            } else if ( token[0] === '}') {
+                this.end(token);
+                break;
+            } else {
+                params.push(token);
+            }
+
+            this.pos += 1;
+        }
+        if ( this.pos === this.tokens.length ) {
+            last = true;
+        }
+
+        node.raws.between = this.spacesFromEnd(params);
+        if ( params.length ) {
+            node.raws.afterName = this.spacesFromStart(params);
+            this.raw(node, 'params', params);
+            if ( last ) {
+                token = params[params.length - 1];
+                node.source.end  = { line: token[4], column: token[5] };
+                this.spaces      = node.raws.between;
+                node.raws.between = '';
+            }
+        } else {
+            node.raws.afterName = '';
+            node.params    = '';
+        }
+
+        if ( open ) {
+            node.nodes  = [];
+            this.current = node;
         }
     }
 

--- a/test/parse.es6
+++ b/test/parse.es6
@@ -22,6 +22,12 @@ describe('SCSS Parser', () => {
         expect(root.first.first.name).to.eql('media');
     });
 
+    it('parses nested at-rules without semicolons', () => {
+        let root = parse('a { @include foo($var: true) }');
+        expect(root.first.first.name).to.eql('include');
+        expect(root.first.first.params).to.eql('foo($var: true)');
+    });
+
     it('parses variables', () => {
         let root = parse('$var: 1;');
         expect(root.first.prop).to.eql('$var');


### PR DESCRIPTION
Fixes #7.

The `atrule` method is just copied from *postcss*, with the addition of the following condition:

```
            } else if ( token[0] === '}') {
                this.end(token);
                break;
```

I think it makes more sense to either add this to *postcss* directly, or to refactor the method in *postcss*, so that more of the code could be shared. What are your preferences on this?