### PR TITLE
added stripSingleLineComment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,13 @@ postcss(plugins).process(scss, { parser: syntax }).then(function (result) {
     result.css // CSS with normal comments
 });
 ```
+
+You can pass the boolean option stripSingleLineComment to remove single line comments 
+rather than convert them to ```/* standard comments */```
+
+```js
+var syntax = require('postcss-scss');
+postcss(plugins).process(scss, { parser: syntax, stripSingleLineComment: true }).then(function (result) {
+    result.css // CSS with normal comments
+});
+```

--- a/lib/scss-parse.es6
+++ b/lib/scss-parse.es6
@@ -6,7 +6,7 @@ export default function scssParse(scss, opts) {
     let input = new Input(scss, opts);
 
     let parser = new ScssParser(input);
-    parser.tokenize();
+    parser.tokenize(opts);
     parser.loop();
 
     return parser.root;

--- a/lib/scss-parser.es6
+++ b/lib/scss-parser.es6
@@ -5,8 +5,8 @@ import scssTokenizer from './scss-tokenize';
 
 export default class ScssParser extends Parser {
 
-    tokenize() {
-        this.tokens = scssTokenizer(this.input);
+    tokenize(opts) {
+        this.tokens = scssTokenizer(this.input, opts);
     }
 
     comment(token) {

--- a/lib/scss-tokenize.es6
+++ b/lib/scss-tokenize.es6
@@ -23,7 +23,8 @@ const RE_NEW_LINE    = /[\r\f\n]/g;
 const RE_WORD_END    = /[ \n\t\r\f\(\)\{\}:;@!'"\\#]|\/(?=\*)/g;
 const RE_BAD_BRACKET = /.[\\\/\("'\n]/;
 
-export default function scssTokenize(input) {
+export default function scssTokenize(input, opts) {
+    opts = opts || {};
     let tokens = [];
     let css    = input.css.valueOf();
 
@@ -34,6 +35,15 @@ export default function scssTokenize(input) {
     let offset = -1;
     let line   =  1;
     let pos    =  0;
+
+    let defaults = {
+        stripSingleLineComment: false
+    };
+    for (let name in opts) {
+        if (opts.hasOwnProperty(name)) {
+            defaults[name] = opts[name];
+        }
+    }
 
     function unclosed(what) {
         throw input.error('Unclosed ' + what, line, pos - offset);
@@ -272,16 +282,28 @@ export default function scssTokenize(input) {
                 if ( RE_NEW_LINE.lastIndex === 0 ) {
                     next = css.length - 1;
                 } else {
-                    next = RE_NEW_LINE.lastIndex - 2;
+                    let i = defaults.stripSingleLineComment ? 1 : 2;
+                    next = RE_NEW_LINE.lastIndex - i;
                 }
 
-                content = css.slice(pos, next + 1);
+                if (!defaults.stripSingleLineComment) {
+                    content = css.slice(pos, next + 1);
 
-                tokens.push(['comment', content,
-                    line, pos  - offset,
-                    line, next - offset,
-                    'inline'
-                ]);
+                    tokens.push(['comment', content,
+                        line, pos  - offset,
+                        line, next - offset,
+                        'inline'
+                    ]);
+                } else {
+                    let token = tokens[tokens.length - 1];
+                    if (token && token[0] === 'space') {
+                        if (token[1].charCodeAt(0) === NEWLINE) {
+                            token[1] = '\n';
+                        } else {
+                            tokens.pop();
+                        }
+                    }
+                }
 
                 pos = next;
 

--- a/test/tokenize.es6
+++ b/test/tokenize.es6
@@ -3,8 +3,8 @@ import tokenize from '../lib/scss-tokenize';
 import { expect } from 'chai';
 import   Input    from 'postcss/lib/input';
 
-let test = (css, tokens) => {
-    expect(tokenize(new Input(css))).to.eql(tokens);
+let test = (css, tokens, opts) => {
+    expect(tokenize(new Input(css), opts)).to.eql(tokens);
 };
 
 describe('SCSS Tokenizer', () => {
@@ -27,4 +27,15 @@ describe('SCSS Tokenizer', () => {
         test('#{a\nb}', [ ['word', '#{a\nb}', 1, 1, 2, 2] ]);
     });
 
+    it('tokenizes accepts stripSingleLineComment argument', () => {
+        test('// a', [], { stripSingleLineComment: true });
+    });
+
+    it('tokenizes stripSingleLineComment removes leading spaces', () => {
+        test('#a{\n    // b\n}', [ [ 'word', '#a', 1, 1, 1, 2 ],
+                                   [ '{', '{', 1, 3 ],
+                                   [ 'space', '\n' ],
+                                   [ '}', '}', 2, 10 ] ],
+                                   { stripSingleLineComment: true });
+    });
 });


### PR DESCRIPTION
At present single line comments are wrapped in standard CSS comments, however it would be useful to have the feature where normal CSS comments render, and single line comments do not.

```css
/* This comment is kept */
#a {
    // This comment is stripped
}
// So is this comment
```
The postcss-scss plugin is methodical at 'tokenizing' the CSS files, which provides for greater control over single line comments. Most other [single line comment plugins](https://github.com/postcss/postcss/issues/362) offer limited support for removal, I think due to it not being done at the parser level. This is especially important when using a custom ```@import``` plugin which will run before other postcss plugins.