### PR TITLE
[discussion needed] Add support for nested properties

### DIFF
--- a/lib/declaration-nested.es6
+++ b/lib/declaration-nested.es6
@@ -1,0 +1,115 @@
+import warnOnce     from 'postcss/lib/warn-once';
+import Container    from 'postcss/lib/container';
+
+/**
+ * Represents a CSS declaration with nested properties
+ * Basically a copy of PostCSS's Declaration, but inherits not form Node, but
+ * from Container - to be able to contain other Nodes
+ *
+ * @extends Container
+ *
+ * @example
+ * const root = postcss.parse('a { margin: 10px { left: 0; } }');
+ * const decl = root.first.first;
+ * decl.type       //=> 'decl'
+ * decl.toString() //=> 'margin: 10px { left: 0; }'
+ */
+class DeclarationNested extends Container {
+
+    constructor(defaults) {
+        super(defaults);
+        this.type = 'decl';
+        if ( !this.nodes ) this.nodes = [];
+    }
+
+    get _value() {
+        warnOnce('Node#_value was deprecated. Use Node#raws.value');
+        return this.raws.value;
+    }
+
+    set _value(val) {
+        warnOnce('Node#_value was deprecated. Use Node#raws.value');
+        this.raws.value = val;
+    }
+
+    get _important() {
+        warnOnce('Node#_important was deprecated. Use Node#raws.important');
+        return this.raws.important;
+    }
+
+    set _important(val) {
+        warnOnce('Node#_important was deprecated. Use Node#raws.important');
+        this.raws.important = val;
+    }
+
+    /**
+     * @memberof DeclarationNested#
+     * @member {string} prop - the declaration’s property name
+     *
+     * @example
+     * const root = postcss.parse('a { margin: 10px { left: 0; } }');
+     * const decl = root.first.first;
+     * decl.prop //=> 'margin'
+     */
+
+    /**
+     * @memberof DeclarationNested#
+     * @member {string} value - the declaration’s value
+     *
+     * @example
+     * const root = postcss.parse('a { margin: { left: 0; } }');
+     * const decl = root.first.first;
+     * decl.value //=> ''
+     */
+
+    /**
+     * @memberof DeclarationNested#
+     * @member {boolean} important - `true` if the declaration
+     *                               has an !important annotation.
+     *
+     * @example
+     * const root = postcss.parse('a { margin: 10px !important { left: 0; } }');
+     * root.first.first.important //=> true
+     * root.first.last.important  //=> undefined
+     */
+
+    /**
+     * @memberof DeclarationNested#
+     * @member {boolean} isNested - `true` if the declaration has nested
+     *                            properties.
+     *
+     * @example
+     * const root = postcss.parse('a { margin: 10px { left: 0; } }');
+     * root.first.first.nested //=> true
+     */
+
+    /**
+     * @memberof DeclarationNested#
+     * @member {object} raws - Information to generate byte-to-byte equal
+     *                         node string as it was in the origin input.
+     *
+     * Every parser saves its own properties,
+     * but the default CSS parser uses:
+     *
+     * * `before`: the space symbols before the node. It also stores `*`
+     *   and `_` symbols before the declaration (IE hack).
+     * * `between`: the symbols between the property and value
+     *   for declarations, selector and `{` for rules, or last parameter
+     *   and `{` for at-rules.
+     * * `important`: the content of the important statement,
+     *   if it is not just `!important`.
+     * * `isNestetProps`: true, if this declaration has nested properties
+     *
+     * PostCSS cleans declaration from comments and extra spaces,
+     * but it stores origin content in raws properties.
+     * As such, if you don’t change a declaration’s value,
+     * PostCSS will use the raw value with comments.
+     *
+     * @example
+     * const root = postcss.parse('a {\n  color:black\n}')
+     * root.first.first.raws //=> { before: '\n  ', between: ':' }
+     */
+
+}
+
+export default DeclarationNested;

--- a/lib/scss-parser.es6
+++ b/lib/scss-parser.es6
@@ -2,6 +2,7 @@ import Comment from 'postcss/lib/comment';
 import Parser  from 'postcss/lib/parser';
 
 import scssTokenizer from './scss-tokenize';
+import DeclarationNested from './declaration-nested';
 
 export default class ScssParser extends Parser {
 
@@ -9,15 +10,163 @@ export default class ScssParser extends Parser {
         this.tokens = scssTokenizer(this.input);
     }
 
+    rule(tokens) {
+        const tokensCommentless = [];
+
+        let colonIndex = null;
+        let isSpaceAfterColon = null;
+        let value = null;
+
+        // Strip comments (and join adjacent spaces) so that they don't mess
+        // the checking
+        for (let i = 0; i < tokens.length; i++) {
+            const type = tokens[i][0];
+            const lastTokenCommentless =
+                tokensCommentless[tokensCommentless.length - 1];
+            if (type === 'comment') {
+                continue;
+            } else if (type === 'space' && lastTokenCommentless &&
+                lastTokenCommentless[0] === 'space'
+           ) {
+                lastTokenCommentless[1] += tokens[i][1];
+            } else {
+                tokensCommentless.push(tokens[i]);
+            }
+        }
+        // removing the last `{`
+        tokensCommentless.pop();
+
+        if (tokensCommentless[1] && tokensCommentless[1][0] === ':') {
+            colonIndex = 1;
+        } else if (tokensCommentless[2] && tokensCommentless[2][0] === ':') {
+            colonIndex = 2;
+        }
+        if (colonIndex) {
+            isSpaceAfterColon = tokensCommentless[colonIndex + 1] &&
+                tokensCommentless[colonIndex + 1][0] === 'space';
+            value = isSpaceAfterColon ?
+                tokensCommentless[colonIndex + 2] &&
+                    tokensCommentless[colonIndex + 2][1] :
+                tokensCommentless[colonIndex + 1] &&
+                    tokensCommentless[colonIndex + 1][1];
+        }
+
+        // If the conditions for compiling it as a nested prop (and not
+        // a selector as with `a :before`) are right
+        if (colonIndex &&
+            (value === null || isSpaceAfterColon ||
+            /[0-9.$]/.test(value[0]))
+       ) {
+            tokens.pop();
+            // This code chunk is basically an almost exact copy of PostCSS'
+            // Parser.decl(), except `DeclarationNested` is used instead of
+            // `Declaration`, no ; is needed, and the very last part
+            let node = new DeclarationNested();
+            this.init(node);
+
+            let last = tokens[tokens.length - 1];
+            if (last[4]) {
+                node.source.end = { line: last[4], column: last[5] };
+            } else {
+                node.source.end = { line: last[2], column: last[3] };
+            }
+
+            while (tokens[0][0] !== 'word') {
+                node.raws.before += tokens.shift()[1];
+            }
+            node.source.start = { line: tokens[0][2], column: tokens[0][3] };
+
+            node.prop = '';
+            while (tokens.length) {
+                let type = tokens[0][0];
+                if (type === ':' || type === 'space' || type === 'comment') {
+                    break;
+                }
+                node.prop += tokens.shift()[1];
+            }
+
+            node.raws.between = '';
+
+            let token;
+            while (tokens.length) {
+                token = tokens.shift();
+
+                if (token[0] === ':') {
+                    node.raws.between += token[1];
+                    break;
+                } else {
+                    node.raws.between += token[1];
+                }
+            }
+
+            if (node.prop[0] === '_' || node.prop[0] === '*') {
+                node.raws.before += node.prop[0];
+                node.prop = node.prop.slice(1);
+            }
+            node.raws.between += this.spacesFromStart(tokens);
+            this.precheckMissedSemicolon(tokens);
+
+            for (let i = tokens.length - 1; i > 0; i--) {
+                token = tokens[i];
+                if (token[1] === '!important') {
+                    node.important = true;
+                    let string = this.stringFrom(tokens, i);
+                    string = this.spacesFromEnd(tokens) + string;
+                    if (string !== ' !important') {
+                        node.raws.important = string;
+                    }
+                    break;
+
+                } else if (token[1] === 'important') {
+                    let cache = tokens.slice(0);
+                    let str   = '';
+                    for (let j = i; j > 0; j--) {
+                        let type = cache[j][0];
+                        if (str.trim().indexOf('!') === 0 &&
+                            type !== 'space'
+                        ) {
+                            break;
+                        }
+                        str = cache.pop()[1] + str;
+                    }
+                    if (str.trim().indexOf('!') === 0) {
+                        node.important = true;
+                        node.raws.important = str;
+                        tokens = cache;
+                    }
+                }
+
+                if (token[0] !== 'space' && token[0] !== 'comment') {
+                    break;
+                }
+            }
+
+            this.raw(node, 'value', tokens);
+
+            if (node.value.indexOf(':') !== -1) {
+                this.checkMissedSemicolon(tokens);
+            }
+
+            // Giving it a "nested" flag
+            node.raws.isNestedProp = true;
+            node.isNested = true;
+            // So that the following decls got inside this one
+            this.current = node;
+        } else {
+            // Otherwise it's a usual ruleset
+            super.rule(tokens);
+        }
+    }
+
     comment(token) {
-        if ( token[6] === 'inline' ) {
+        if (token[6] === 'inline') {
             let node = new Comment();
             this.init(node, token[2], token[3]);
             node.raws.inline = true;
             node.source.end  = { line: token[4], column: token[5] };
 
             let text = token[1].slice(2);
-            if ( /^\s*$/.test(text) ) {
+            if (/^\s*$/.test(text)) {
                 node.text       = '';
                 node.raws.left  = text;
                 node.raws.right = '';

--- a/lib/scss-stringifier.es6
+++ b/lib/scss-stringifier.es6
@@ -13,4 +13,34 @@ export default class ScssStringifier extends Stringifier {
         }
     }
 
+    decl(node, semicolon) {
+        // Starting as with a usual declaration
+        let between = this.raw(node, 'between', 'colon');
+        let string  = node.prop + between + this.rawValue(node, 'value');
+
+        if (node.important) {
+            string += node.raws.important || ' !important';
+        }
+
+        if (node.isNested) {
+            // If it's nested, go all block-ish
+            this.builder(string + '{', node, 'start');
+
+            let after;
+            if (node.nodes && node.nodes.length) {
+                this.body(node);
+                after = this.raw(node, 'after');
+            } else {
+                after = this.raw(node, 'after', 'emptyBody');
+            }
+
+            if (after) this.builder(after);
+            this.builder('}', node, 'end');
+        } else {
+            // if not - finish as a usual declaration
+            if (semicolon) string += ';';
+            this.builder(string, node);
+        }
+    }
+
 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -93,3 +93,114 @@ test('parses interpolation in url()', t => {
     let root = parse('image: url(#{get(path)}.png)');
     t.deepEqual(root.first.value, 'url(#{get(path)}.png)');
 });
+
+// Nested properties
+test('Parse: nested props (no root prop value)', t => {
+    let root = parse('a { margin: { left: 10px; }}');
+    t.deepEqual(root.first.selector, 'a');
+
+    t.deepEqual(root.first.first.prop, 'margin');
+    t.deepEqual(root.first.first.value, '');
+
+    t.deepEqual(root.first.first.first.prop, 'left');
+    t.deepEqual(root.first.first.first.value, '10px');
+});
+
+test('Parse: nested prop with root value.', t => {
+    let root = parse('a { margin: 0 { left: 10px; }}');
+    t.deepEqual(root.first.selector, 'a');
+
+    t.deepEqual(root.first.first.prop, 'margin');
+    t.deepEqual(root.first.first.value, '0');
+    t.deepEqual(root.first.first.raws.between, ': ');
+
+    t.deepEqual(root.first.first.first.prop, 'left');
+    t.deepEqual(root.first.first.first.value, '10px');
+});
+
+test('Parse: nested prop with variable as root value (`margin:$var`).', t => {
+    let root = parse('a { margin:$var { left: 10px; }}');
+    t.deepEqual(root.first.selector, 'a');
+
+    t.deepEqual(root.first.first.prop, 'margin');
+    t.deepEqual(root.first.first.value, '$var');
+    t.deepEqual(root.first.first.raws.between, ':');
+
+    t.deepEqual(root.first.first.first.prop, 'left');
+    t.deepEqual(root.first.first.first.value, '10px');
+});
+
+test('Parse: nested prop with variable as root value (`margin :$vars`).', t => {
+    let root = parse('a { margin :$vars { left: 10px; }}');
+    t.deepEqual(root.first.selector, 'a');
+
+    t.deepEqual(root.first.first.prop, 'margin');
+    t.deepEqual(root.first.first.value, '$vars');
+    t.deepEqual(root.first.first.raws.between, ' :');
+
+    t.deepEqual(root.first.first.first.prop, 'left');
+    t.deepEqual(root.first.first.first.value, '10px');
+});
+
+test('Parse: nested prop with root value (`margin:0`).', t => {
+    let root = parse('a { margin:0 { left: 10px; }}');
+    t.deepEqual(root.first.selector, 'a');
+
+    t.deepEqual(root.first.first.prop, 'margin');
+    t.deepEqual(root.first.first.value, '0');
+    t.deepEqual(root.first.first.raws.between, ':');
+
+    t.deepEqual(root.first.first.first.prop, 'left');
+    t.deepEqual(root.first.first.first.value, '10px');
+});
+
+test('Parse: selector `margin:text` (that might look like a nested prop)', t => {
+    let root = parse('a { \n margin:text { left: 10px; }}');
+    t.deepEqual(root.first.selector, 'a');
+
+    t.deepEqual(root.first.first.prop, undefined);
+    t.deepEqual(root.first.first.selector, 'margin:text');
+});
+
+test('Parse: selector `margin  \n:after` (that might look like a nested prop)', t => {
+    let root = parse('a { \n margin  \n:after { left: 10px; }}');
+    t.deepEqual(root.first.selector, 'a');
+
+    t.deepEqual(root.first.first.prop, undefined);
+    t.deepEqual(root.first.first.selector, 'margin  \n:after');
+});
+
+test('Parse: nested prop with important', t => {
+    let root = parse('a { \n margin : 0!important { left: 10px; }}');
+    t.deepEqual(root.first.selector, 'a');
+
+    t.deepEqual(root.first.first.prop, 'margin');
+    t.deepEqual(root.first.first.value, '0');
+    t.deepEqual(root.first.first.important, true);
+});
+
+test('Parse: nested prop with CSS comment between root prop and value', t => {
+    let root = parse('a { margin: /* comment*/ 0em { left: 10px; }}');
+    t.deepEqual(root.first.selector, 'a');
+
+    t.deepEqual(root.first.first.prop, 'margin');
+    t.deepEqual(root.first.first.value, '0em');
+    
+    t.deepEqual(root.first.first.first.prop, 'left');
+    t.deepEqual(root.first.first.first.value, '10px');
+});
+
+test('Parse: nested prop with //-comment', t => {
+    let root = parse(`
+        a {
+            margin: // comment
+            {
+                left: 10px;
+            }
+        }
+    `);
+    t.deepEqual(root.first.selector, 'a');
+
+    t.deepEqual(root.first.first.prop, 'margin');
+    t.deepEqual(root.first.first.value, '');
+});

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -34,3 +34,30 @@ test('stringifies inline comment in the end of file', t => {
     });
     t.deepEqual(result, '// comment');
 });
+
+test('stringifies rule with usual props', t => {
+    let root   = parse('a { color: red; text-align: justify ; }');
+    let result = '';
+    stringify(root, i => {
+        result += i;
+    });
+    t.deepEqual(result, 'a { color: red; text-align: justify ; }');
+});
+
+test('Stringify: nested props', t => {
+    let root   = parse('a { \n margin : 0!important { left: 10px; }}');
+    let result = '';
+    stringify(root, i => {
+        result += i;
+    });
+    t.deepEqual(result, 'a { \n margin : 0!important { left: 10px; }}');
+});
+
+test('Stringify: nested props with more newlines', t => {
+    let root   = parse('a { \n margin : 0 !important \n { \n left: 10px; } \n}');
+    let result = '';
+    stringify(root, i => {
+        result += i;
+    });
+    t.deepEqual(result, 'a { \n margin : 0 !important \n { \n left: 10px; } \n}');
+});


### PR DESCRIPTION
Implements #39 

This is a temporary commit, I wanted to show the progress so far and more importantly discuss some moments.

So there are two main options for implementing the nested props parsing: 1) extend Declaration (breaking change),  or 2) add a bunch of props to `Rule` objects (backwards compatible)

## 1) Extend a Declaration (add new class)

The pros:

* Makes sense in terms of semantics (nested group is a declaration with other decls inside).

The cons:

* Breaking change. Will possibly require to release the new major version not to break existing code. (Actually, I'm not sure it's such a problem, as the current way of parsing nested props is actually wrong and the proposed change is a fix).
* Requires some tweaks to PostCSS (small ones, they will not break anything).

I personally like this option much more, and will go on in a more detail with implementation of it.

The idea is to make decls that have nested props to be Containers. They'll need the the `push` method (for [the parser](https://github.com/postcss/postcss/blob/master/lib/parser.es6#L338) not to throw on them) and `walk` and other methods. Usual decls like `position: absolute;` will continue to use the Declaration class.

The [implementation](https://github.com/dryoma/postcss-scss/blob/nested-props/lib/declaration-nested.es6) is quite straightforward. The problem is: instead of copying the original parser's [`decl` method](https://github.com/postcss/postcss/blob/master/lib/parser.es6#L167) (it's quite intricate, and if some chanegs are required, they'd have to be reflected in the copied method) I'd rather just [call it](https://github.com/postcss/postcss-scss/compare/master...dryoma:nested-props?expand=1#diff-ba0ca06ddfcb75937d407bbfecc329a2R37), but there is no sane way to use the new DeclarationNested class/constructor. It would be best if we would be able to use it [here](https://github.com/postcss/postcss/blob/master/lib/parser.es6#L168). I made [a couple](https://github.com/postcss/postcss-scss/compare/master...dryoma:nested-props?expand=1#diff-ba0ca06ddfcb75937d407bbfecc329a2R40) of [hacks](https://github.com/postcss/postcss-scss/compare/master...dryoma:nested-props?expand=1#diff-ba0ca06ddfcb75937d407bbfecc329a2R42) for the parser to work, yet it's not the right way to solve things.

So I propose these additions to the original PostCSS:

* Add the ability to instantiate the declaration with a selected class. Namely, [change](https://github.com/postcss/postcss/blob/master/lib/parser.es6#L167) `decl(tokens)` to `decl(token, class)`: if the class is passed, use it [here](https://github.com/postcss/postcss/blob/master/lib/parser.es6#L168), if not - use Declaration.
* Maybe `return node` in the parsers methods? for [easier access](https://github.com/dryoma/postcss-scss/blob/nested-props/lib/scss-parser.es6#L38) to the objects created by them.

@ai what do you think? or maybe you could suggest some other ways to achieve these.

## 2) Extend the Rule object (not the prototype)

There is another option, that is really bizzare I think.

E.g.
```scss
margin: 0px {
	left: 10px;
}
```

```js
Rule {
	// all the usual Rule methods and props
	selector: 'margin: 0px', // !!
	nested: true,
	prop: 'margin',
	value: '0px',
	raws: { ... , /* reflect spaces between prop and value, etc. */}
}
```

The pro: compatibility with the existing code relying on postcss-scss. If users wanted to utilize nested props, they'd only have to check the newly added props (`nested`, `value`, `prop`).

The cons:

* Doesn't make sence. Nested property group is not a ruleset, it's a declaration that has other props (parts to be exact) inside.
* All the errors remain intact, e.g. parsing `margin: 0px` as a selector, etc.
* Adding `nested`, `value`, `prop` is easy, but for raws some new convention will be needed. Like, what is `between` - `: ` or ` ` (before the `{`), etc.

-----------

I'd also like to hear the opinions of the guys from stylelint community (@davidtheclark, @jeddy3, @kristerkari), namely the thoughts on the options proposed.