### PR TITLE
Travis CI: Switch from `stable` to `7` to use the latest/current NodeJS 7.x.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - stable
+  - "7"
   - "6"
   - "4"
   - "0.12"


### PR DESCRIPTION
Currently NodeJS is only using NodeJS v7.0.0.

Switching this to `7` will use the latest/stable NodeJS 7 branch which is currently `7.4.0`

e.g. https://travis-ci.org/postcss/postcss-scss/jobs/173199422#L138

FYI: The NVM alias `stable` was deprecated quite some time ago