### PR TITLE
There was no simple parsing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ yarn install --dev postcss-scss
 
 ## Usage
 
+### Simple parsing example
+
+We parse SCSS files the same way as we do vanilla CSS, except we provide
+postcss-scss as the syntax object.
+
+```js
+var syntax = require('postcss-scss');
+
+var root = postcss.parse(rawSCSS, { syntax: syntax });
+```
+
 ### SCSS Transformations
 
 The main use case of this plugin is to apply PostCSS transformations directly


### PR DESCRIPTION
Since this library addresses the parsing of SCSS and not the processing of it, I felt it made sense that the first example should be parsing, and not processing.

I imagine this would be useful to a noob coming across this repo.