### PR TITLE
Edit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ postcss(plugins).process(scss, { syntax: syntax }).then(function (result) {
 This module also enables parsing of single-line comments in CSS source code.
 
 ```scss
-:root {
+.block {
     // Main theme color
-    --color: red;
+    color: green;
 }
 ```
 


### PR DESCRIPTION
Not an obvious example in the description. At first glance, I began to think that the plug-in supports only such variables.