### PR TITLE
Fix incorrect generic type parameter

### DIFF
--- a/lib/scss-syntax.d.ts
+++ b/lib/scss-syntax.d.ts
@@ -1,4 +1,4 @@
 import * as postcss from 'postcss';
 
-export const parse: postcss.Parser;
+export const parse: postcss.Parser<postcss.Root>;
 export const stringify: postcss.Stringifier;


### PR DESCRIPTION
The introduction of the `Document` type [in this PR](https://github.com/postcss/postcss/pull/1582) incorrectly advertises that `parse` can return a `Document` object, because the [`Parser` interface is now generic](https://github.com/postcss/postcss/pull/1582/files#diff-68ba6abc949516587990ca61016794e81039fd6ae58437d5cfaccd4eeebdac07R224).

This PR exposes the parser as a more specific type of `Parser` so that consumers aren't given a `Root | Document`, but just a `Root`.