### PR TITLE
fix: improve compat with ts in node16/bundler mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "types": "lib/scss-syntax.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/scss-syntax.d.ts",
       "require": "./lib/scss-syntax.js",
       "import": "./lib/scss-syntax.mjs"
     },


### PR DESCRIPTION
when using the newer resolution and module modes of typescript, it could pick up `./lib/scss-syntax.mjs`, which does not have a `.d.ts` file next to it. added the `"types"` condition to ensure imports to `"postcss-scss"` always get a type, no matter if they are sourced in commonjs or esm.