### PR TITLE
fix: node end offset location

### DIFF
--- a/lib/scss-parser.js
+++ b/lib/scss-parser.js
@@ -28,7 +28,11 @@ class ScssParser extends Parser {
       this.init(node, token[2])
       node.raws.inline = true
       let pos = this.input.fromOffset(token[3])
-      node.source.end = { column: pos.col, line: pos.line, offset: token[3] }
+      node.source.end = {
+        column: pos.col,
+        line: pos.line,
+        offset: token[3] + 1
+      }
 
       let text = token[1].slice(2)
       if (/^\s*$/.test(text)) {
@@ -106,10 +110,18 @@ class ScssParser extends Parser {
       }
       if (last[3]) {
         let pos = this.input.fromOffset(last[3])
-        node.source.end = { column: pos.col, line: pos.line, offset: last[3] }
+        node.source.end = {
+          column: pos.col,
+          line: pos.line,
+          offset: last[3] + 1
+        }
       } else {
         let pos = this.input.fromOffset(last[2])
-        node.source.end = { column: pos.col, line: pos.line, offset: last[2] }
+        node.source.end = {
+          column: pos.col,
+          line: pos.line,
+          offset: last[2] + 1
+        }
       }
 
       while (tokens[0][0] !== 'word') {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     }
   ],
   "peerDependencies": {
-    "postcss": "^8.4.19"
+    "postcss": "^8.4.29"
   },
   "devDependencies": {
     "@logux/eslint-config": "^51.0.1",
@@ -65,8 +65,8 @@
     "eslint-plugin-perfectionist": "^1.5.1",
     "eslint-plugin-prefer-let": "^3.0.1",
     "eslint-plugin-promise": "^6.1.1",
-    "postcss": "^8.4.27",
-    "postcss-parser-tests": "^8.6.0",
+    "postcss": "^8.4.29",
+    "postcss-parser-tests": "^8.8.0",
     "uvu": "^0.5.6"
   },
   "prettier": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,11 +33,11 @@ devDependencies:
     specifier: ^6.1.1
     version: 6.1.1(eslint@8.47.0)
   postcss:
-    specifier: ^8.4.27
-    version: 8.4.27
+    specifier: ^8.4.29
+    version: 8.4.29
   postcss-parser-tests:
-    specifier: ^8.6.0
-    version: 8.6.0
+    specifier: ^8.8.0
+    version: 8.8.0
   uvu:
     specifier: ^0.5.6
     version: 0.5.6
@@ -1419,14 +1419,14 @@ packages:
     engines: {node: '>=8.6'}
     dev: true
 
-  /postcss-parser-tests@8.6.0:
-    resolution: {integrity: sha512-r5P5I4AsL62mlF9KXA1oL/Oel7+wJnwGfQnOA4fMhA54Lx1Pae+67OLmkgla3dAOIpr0FgNjAJg0zxW0CQlrUg==}
+  /postcss-parser-tests@8.8.0:
+    resolution: {integrity: sha512-vAyVrBzp7YmfpmjCG3RGhilE9+oydj6oTZYWMBwkp/3FVOdUURerTRD0w/NVegOreAj51tCPqgCwbb4AW5f5SA==}
     dependencies:
       picocolors: 1.0.0
     dev: true
 
-  /postcss@8.4.27:
-    resolution: {integrity: sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==}
+  /postcss@8.4.29:
+    resolution: {integrity: sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.6

--- a/test/location.test.js
+++ b/test/location.test.js
@@ -1,0 +1,29 @@
+let { equal } = require('uvu/assert')
+let { test } = require('uvu')
+
+let parse = require('../lib/scss-parse')
+
+function checkOffset(source, node, expected) {
+  let start = node.source.start.offset
+  let end = node.source.end.offset
+  equal(source.slice(start, end), expected)
+}
+
+test('inline comment', () => {
+  let source = 'a{//xxx\n}'
+  let root = parse(source)
+
+  checkOffset(source, root.first, 'a{//xxx\n}')
+  checkOffset(source, root.first.first, '//xxx')
+})
+
+test('nested prop with value', () => {
+  let source = 'a { margin: 0 { left: 10px; }}'
+  let root = parse(source)
+
+  checkOffset(source, root.first, 'a { margin: 0 { left: 10px; }}')
+  checkOffset(source, root.first.first, 'margin: 0 { left: 10px; }')
+  checkOffset(source, root.first.first.first, 'left: 10px;')
+})
+
+test.run()

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -7,7 +7,7 @@ let parse = require('../lib/scss-parse')
 eachTest((name, css, json) => {
   test('parses ' + name, () => {
     let parsed = jsonify(parse(css, { from: name }))
-    equal(JSON.parse(parsed), JSON.parse(json))
+    equal(parsed, json)
   })
 })
 


### PR DESCRIPTION
This PR fixes the offset of specific sass ast nodes mentioned in [this issue](https://github.com/postcss/postcss-scss/issues/146).

I had to upgrade the dev dependencies of both `postcss` and `postcss-parser-tests` to make this work. And also set the minimal `postcss` version from `"^8.4.19"` to `"^8.4.29"`.

Upgrading the `post-parser-tests` also required a small change in the test that used it since it changed `jsonify` from returning string to object.

The actual fix changed the offset in 3 places, but I only added tests for 2 cases, since I couldn't figure out what syntax can result in the parser [reaching the 3rd offset](https://github.com/postcss/postcss-scss/pull/147/files#diff-e6a77268c01419168449dcad397685461c8618bd85c38b648f3a937e9a9dc0dfR120).